### PR TITLE
Fix tokenizer mis-lexing nested dot access (o.i.a) as '...'

### DIFF
--- a/c8080_source/c/parser/ctokenizer.cpp
+++ b/c8080_source/c/parser/ctokenizer.cpp
@@ -199,7 +199,7 @@ CToken CTokenizer::NextToken3() {
             }
             return CT_OPERATOR;
         case '.':
-            if (*cursor == '.' || cursor[1] == '.')  // ...
+            if (*cursor == '.' && cursor[1] == '.')  // ...
                 cursor += 2;
             return CT_OPERATOR;
         case '+':

--- a/tests/nested_dot.c
+++ b/tests/nested_dot.c
@@ -1,0 +1,21 @@
+// Regression test for nested struct member access.
+//
+// Before the ctokenizer.cpp:202 fix, the tokenizer treated any `.X.`
+// sequence as the `...` operator, so `o.i.a` was lexed as the single
+// token `.i.` and the parser reported "unexpected '.i.'".
+//
+// Expected behaviour: compiles without error.
+
+struct Inner {
+    int a;
+};
+
+struct Outer {
+    struct Inner i;
+};
+
+void __main()
+{
+    struct Outer o;
+    o.i.a = 42;
+}


### PR DESCRIPTION
## Summary
- `ctokenizer.cpp:202` uses `||` instead of `&&` in the `...` operator branch, so the tokenizer treats any `.X.` sequence as the ellipsis — it consumes two chars past the leading dot.
- Result: nested struct member access like `o.i.a` tokenises as `o` `.i.` `a` and the parser rejects it with `error: syntax error, unexpected '.i.'`.
- Fix: change `||` → `&&` so the ellipsis only fires when the next two chars really are `..`. Simple variadic usage (`void f(...)`, `printf`, etc.) is unaffected.
- Adds a minimal regression reproducer at `tests/nested_dot.c`.

## Test plan
- [x] Reproduce on `main`: `c8080 tests/nested_dot.c` → `error: syntax error, unexpected '.i.'`.
- [x] After fix: compiles cleanly.
- [x] Cross-verified against the c8080-js TypeScript port, which carries the same `&&` change and has a passing end-to-end test for `o.i.a` plus the full variadic-`printf` path.

## Notes
Non-blocking, unrelated: `main` currently fails to build on clean gcc 13/14 due to a stale `.value` field reference in `c8080_source/8080/cmm/cmm.cpp:559` (the field is now `numeric_value` / `string_value` / `ToString()` — see the sibling site at `8080/compiler/Compile.cpp:132`), plus a missing `<cstdint>` include in `c/tools/cdecodestring.h` and a missing `<string>` include in `8080/asm/asmalu.cpp`. Happy to send those in a separate PR.