### PR TITLE
Fix build on clean gcc 13+ (missing includes, stale field ref)

### DIFF
--- a/c8080_source/8080/asm/asmalu.cpp
+++ b/c8080_source/8080/asm/asmalu.cpp
@@ -18,6 +18,7 @@
 #include "asmalu.h"
 #include <array>
 #include <stdexcept>
+#include <string>
 
 namespace I8080 {
 

--- a/c8080_source/8080/cmm/cmm.cpp
+++ b/c8080_source/8080/cmm/cmm.cpp
@@ -556,7 +556,7 @@ void Cmm::CompileDeclareVariable(CNodePtr &n) {
     if (n->extern_flag || (v.type.pointers.empty() && v.type.flag_const)) {
         if (v.address_attribute.exists) {
             out.source(n->e);
-            out.equ(v.output_name, std::to_string(v.address_attribute.value));
+            out.equ(v.output_name, v.address_attribute.ToString());
         }
         return;
     }

--- a/c8080_source/c/tools/cdecodestring.h
+++ b/c8080_source/c/tools/cdecodestring.h
@@ -19,5 +19,6 @@
 
 #include <string>
 #include <map>
+#include <stdint.h>
 
 const char *CDecodeString(std::string &str, std::map<uint32_t, uint8_t> *codepage);


### PR DESCRIPTION
## Summary
Three independent build breaks on a pristine checkout of `main`, each a one-liner:

- `c8080_source/8080/cmm/cmm.cpp:559` still references the old `CAddressAttribute::value` field. The `__address("any equ text")` feature (51cf11b) renamed it to `numeric_value` / `string_value` + a `ToString()` helper, and the sibling site at `8080/compiler/Compile.cpp:132` already uses `.ToString()`. Switching to `ToString()` here keeps both call sites consistent and supports both numeric and string address attributes.
- `c8080_source/c/tools/cdecodestring.h` uses `uint32_t` / `uint8_t` in the declaration without including `<stdint.h>`. Works on some toolchains where it's pulled in transitively, fails on gcc 13+ with clean libstdc++.
- `c8080_source/8080/asm/asmalu.cpp` uses `std::to_string` without including `<string>`. Same story.

## Test plan
- [x] Pristine `main` fails to build in a clean `gcc:13` Docker container with all three errors above.
- [x] With this PR applied, `make` completes and produces the `c8080` binary.
- [x] Smoke-tested the resulting binary: compiles a trivial `.c` file through all three passes.

Split out of the nested-dot tokenizer PR (#4) per review request.